### PR TITLE
Fix scrolling on mobile devices

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -80,4 +80,9 @@
 
     glitchIt();
 
-    var s = skrollr.init();
+    var isTouchDevice = "ontouchstart" in document.documentElement,
+        s = skrollr;
+
+    if (!isTouchDevice) {
+      s.init();
+    }


### PR DESCRIPTION
Fixes mobile scrolling by only activating skrollr if there is not a "ontouchstart" event.
